### PR TITLE
Open user profile on click

### DIFF
--- a/com.aurum.rust-deck.sdPlugin/manifest.json
+++ b/com.aurum.rust-deck.sdPlugin/manifest.json
@@ -50,6 +50,17 @@
 					"TitleAlignment": "middle"
 				}
 			]
+		},
+		{
+			"Name": "Smart switches",
+			"UUID": "com.aurum.rust-deck.smart-switches",
+			"Icon": "imgs/actions/smart_switches/icon",
+			"Tooltip": "Displays smart switch status, updates every 30 seconds.",
+			"PropertyInspectorPath": "ui/smart-switches.html",
+			"Controllers": [
+				"Keypad"
+			],
+			"Profile": "Smart Switches Profile"
 		}
 	],
 	"Category": "Rust Deck",


### PR DESCRIPTION
Add "Smart switches" action to open a dedicated profile.

This change allows the "Smart switches" button to switch to a specific "Smart Switches Profile" when pressed, as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-d54e3518-411a-4e5f-b399-0cce6bde6375">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d54e3518-411a-4e5f-b399-0cce6bde6375">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>