### PR TITLE
fix(profile-action): adjust refresh logic and interval timing

### DIFF
--- a/src/actions/profile-action.ts
+++ b/src/actions/profile-action.ts
@@ -493,14 +493,15 @@ export class ProfileAction extends SingletonAction<JsonObject> {
       device: ev.action.device,
     });
 
-    if (this.devicesData.length === 0) {
-      this.devicesData = await this.fetchDevicesData();
+    // If this is the first button to appear, trigger a refresh.
+    if (this.knownActions.size === 1) {
+      await this.refreshAll();
     }
 
     await this.updateButton(ev.action, coords, ev.action.device);
 
     if (!this.interval) {
-      this.interval = setInterval(async () => await this.refreshAll(), 500);
+      this.interval = setInterval(() => this.refreshAll(), 5000); // Refresh every 5 seconds
     }
   }
 
@@ -509,10 +510,13 @@ export class ProfileAction extends SingletonAction<JsonObject> {
   ): Promise<void> {
     this.knownActions.delete(ev.action.id);
 
-    if (this.knownActions.size === 0 && this.interval) {
-      clearInterval(this.interval);
-      this.interval = null;
+    if (this.knownActions.size === 0) {
+      if (this.interval) {
+        clearInterval(this.interval);
+        this.interval = null;
+      }
       this.devicesData = [];
+      this.currentPage = 0; // Reset to the first page
       
       // Clean up any remaining timers
       this.buttonPressTimers.forEach(timer => clearTimeout(timer));


### PR DESCRIPTION
- Change refresh trigger condition from empty devicesData to first known action
- Increase refresh interval from 500ms to 5000ms to reduce load
- Reset currentPage when cleaning up actions
- Improve cleanup logic for interval and timers